### PR TITLE
feat: updated deprecated methods to buf.format

### DIFF
--- a/lua/lspcommand.lua
+++ b/lua/lspcommand.lua
@@ -184,15 +184,17 @@ local format = {
       end
 
       if order then
-        buf.formatting_seq_sync(nil, sync, order)
+        for _, name in pairs(order) do
+          buf.format({ async = false, timeout_ms = sync, name = name })
+        end
       else
-        buf.formatting_sync(nil, sync)
+        buf.format({ async = false, timeout_ms = sync })
       end
     else
       if range then
-        buf.range_formatting(nil, range[1], range[2])
+        buf.format({ range = range })
       else
-        buf.formatting()
+        buf.format({ async = true })
       end
     end
   end,

--- a/lua/lspcommand.lua
+++ b/lua/lspcommand.lua
@@ -184,17 +184,33 @@ local format = {
       end
 
       if order then
-        for _, name in pairs(order) do
-          buf.format({ async = false, timeout_ms = sync, name = name })
+        if buf.format then
+          for _, name in pairs(order) do
+            buf.format({ async = false, timeout_ms = sync, name = name })
+          end
+        else
+          buf.formatting_seq_sync(nil, sync, order)
         end
       else
-        buf.format({ async = false, timeout_ms = sync })
+        if buf.format then
+          buf.format({ async = false, timeout_ms = sync })
+        else
+          buf.formatting_sync(nil, sync)
+        end
       end
     else
       if range then
-        buf.format({ range = range })
+        if buf.format then
+          buf.format({ range = range })
+        else
+          buf.range_formatting(nil, range[1], range[2])
+        end
       else
-        buf.format({ async = true })
+        if buf.format then
+          buf.format({ async = true })
+        else
+          buf.formatting()
+        end
       end
     end
   end,


### PR DESCRIPTION
Hi! This PR just contains a small change to the `:Lsp format` command (and its subvariants) to satisfy the deprecation warnings in recent versions of Neovim

When using this plugin on Neovim stable 0.8, Using the format command always prints the deprecation message:
```
vim.lsp.buf.formatting is deprecated. Use vim.lsp.buf.format instead
```

I read through the API docs for `vim.lsp.buf.format` and updated the following sections:
- `buf.formatting()` --> `buf.format({ async = true })`
- `buf.range_formatting(nil, range[1], range[2])` --> `buf.format({ range = range })`
- `buf.formatting_sync(nil, sync)` --> `buf.format({ async = false, timeout_ms = sync })`
- `buf.formatting_seq_sync(nil, sync, order)` --> for loop over `order`, `buf.format({ async = false, timeout_ms = sync, name = name })`

I did some brief testing for each variant and can confirm it all works as expected and doesn't raise a warning anymore. Don't think this requires an update to the docs either.

Let me know if there's anything else I can do to help out with this PR :+1: